### PR TITLE
fix missing logic import

### DIFF
--- a/copy-from-meteor-repo.sh
+++ b/copy-from-meteor-repo.sh
@@ -8,14 +8,14 @@ PKG=../meteor/packages/logic-solver # the Meteor package
 ( echo 'var C_MINISAT;' ; \
     cat $PKG/minisat.js ) > minisat.js
 ( echo 'var C_MINISAT = require("./minisat.js");' ; \
+    echo 'var Logic = require("./logic-solver");' ; \
     echo 'var _ = require("underscore");' ; \
     echo 'var MiniSat;' ; \
     cat $PKG/minisat_wrapper.js ; \
     echo 'module.exports = MiniSat;' ) > minisat_wrapper.js
 ( echo 'var MiniSat = require("./minisat_wrapper.js");' ; \
     echo 'var _ = require("underscore");' ; \
-    echo 'var Logic;' ; \
-    cat $PKG/{types,logic,optimize}.js ;
-    echo 'module.exports = Logic;' ) > logic-solver.js
+    cat $PKG/{types,logic,optimize}.js | sed 's/Logic = {}/var Logic = exports/' ; \
+    ) > logic-solver.js
 
 cp $PKG/README.md README.md

--- a/logic-solver.js
+++ b/logic-solver.js
@@ -1,7 +1,6 @@
 var MiniSat = require("./minisat_wrapper.js");
 var _ = require("underscore");
-var Logic;
-Logic = {};
+var Logic = exports;
 
 ////////// TYPE TESTERS
 
@@ -1843,4 +1842,3 @@ Logic.Solver.prototype.maximizeWeightedSum = function (solution, costTerms,
                                                        costWeights, options) {
   return minMaxWS(this, solution, costTerms, costWeights, options, false);
 };
-module.exports = Logic;

--- a/minisat_wrapper.js
+++ b/minisat_wrapper.js
@@ -1,4 +1,5 @@
 var C_MINISAT = require("./minisat.js");
+var Logic = require("./logic-solver");
 var _ = require("underscore");
 var MiniSat;
 MiniSat = function () {


### PR DESCRIPTION
`minisat_wrapper.js` references `Logic`, but doesn't require it. Running the first example results in the exception

```
$ node example.js
~/sat/node_modules/logic-solver/minisat_wrapper.js:69
  Logic._assertIfEnabled(terms, Logic._isArrayWhere(Logic.isNumTerm));
  ^

ReferenceError: Logic is not defined
    at MiniSat.addClause (~/sat/node_modules/logic-solver/minisat_wrapper.js:69:3)
    at Logic.Solver.solve (~/sat/node_modules/logic-solver/logic-solver.js:1441:34)
    at Object.<anonymous> (~/sat/example.js:24:19)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Function.Module.runMain (module.js:467:10)
    at startup (node.js:136:18)
    at node.js:963:3
```

This change adds the missing require to `minisat_wrapper.js`, and handles the circular dependency between `logic-solver.js` and `minisat_wrapper.js`.
