### PR TITLE
Fix issue with using Logic in minisat file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-*~
+node_modules

--- a/logic-solver.js
+++ b/logic-solver.js
@@ -149,7 +149,6 @@ var assert = Logic._assert;
 Logic._assertIfEnabled = function (value, tester, description) {
   if (assert) assert(value, tester, description);
 };
-var assertIfEnabled = Logic._assertIfEnabled;
 
 // Disabling runtime assertions speeds up clause generation.  Assertions
 // are disabled when the local variable `assert` is null instead of
@@ -1440,7 +1439,7 @@ Logic.Solver.prototype.solve = function (_assumpVar) {
   while (self._numClausesAddedToMiniSat < self.clauses.length) {
     var i = self._numClausesAddedToMiniSat;
     var terms = self.clauses[i].terms;
-    assertIfEnabled(terms, isArrayWhere(Logic.isNumTerm));
+    if (assert) assert(terms, isArrayWhere(Logic.isNumTerm));
     var stillSat = self._minisat.addClause(terms);
     self._numClausesAddedToMiniSat++;
     if (! stillSat) {
@@ -1449,7 +1448,7 @@ Logic.Solver.prototype.solve = function (_assumpVar) {
     }
   }
 
-  assertIfEnabled(this._num2name.length - 1, Logic.isWholeNumber);
+  if (assert) assert(this._num2name.length - 1, Logic.isWholeNumber);
   self._minisat.ensureVar(this._num2name.length - 1);
 
   var stillSat = (_assumpVar ?

--- a/logic-solver.js
+++ b/logic-solver.js
@@ -149,6 +149,7 @@ var assert = Logic._assert;
 Logic._assertIfEnabled = function (value, tester, description) {
   if (assert) assert(value, tester, description);
 };
+var assertIfEnabled = Logic._assertIfEnabled;
 
 // Disabling runtime assertions speeds up clause generation.  Assertions
 // are disabled when the local variable `assert` is null instead of
@@ -1438,13 +1439,17 @@ Logic.Solver.prototype.solve = function (_assumpVar) {
 
   while (self._numClausesAddedToMiniSat < self.clauses.length) {
     var i = self._numClausesAddedToMiniSat;
-    var stillSat = self._minisat.addClause(self.clauses[i].terms);
+    var terms = self.clauses[i].terms;
+    assertIfEnabled(terms, isArrayWhere(Logic.isNumTerm));
+    var stillSat = self._minisat.addClause(terms);
     self._numClausesAddedToMiniSat++;
     if (! stillSat) {
       self._unsat = true;
       return null;
     }
   }
+
+  assertIfEnabled(this._num2name.length - 1, Logic.isWholeNumber);
   self._minisat.ensureVar(this._num2name.length - 1);
 
   var stillSat = (_assumpVar ?

--- a/minisat_wrapper.js
+++ b/minisat_wrapper.js
@@ -57,7 +57,6 @@ MiniSat = function () {
 // C and D, calling ensureVar(4) will make MiniSat give us
 // solution values for them anyway.
 MiniSat.prototype.ensureVar = function (v) {
-  Logic._assertIfEnabled(v, Logic.isWholeNumber);
   this._C._ensureVar(v);
 };
 
@@ -66,7 +65,6 @@ MiniSat.prototype.ensureVar = function (v) {
 // (as far as we know without doing more work), and false if
 // we can already tell that it is unsatisfiable.
 MiniSat.prototype.addClause = function (terms) {
-  Logic._assertIfEnabled(terms, Logic._isArrayWhere(Logic.isNumTerm));
   this._clauses.push(terms);
   return this._native.savingStack(function (native, C) {
     var termsPtr = C.allocate((terms.length+1)*4, 'i32', C.ALLOC_STACK);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "logic-solver",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "General satisfiability solver for logic problems",
     "main": "logic-solver.js",
     "repository": {


### PR DESCRIPTION
@dgreensp I'm not sure if you'll get this, but I'd like to release this as 2.0.1 -- the 2.0.0 version does not actually work due to references to `Logic` inside the `minisat_wrapper` file.
